### PR TITLE
Updated premake dependencies

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -8,7 +8,7 @@ REM Remove existing premake archive
 if exist "premake.zip" del /F/Q premake.zip
 
 REM Download premake
-powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/premake/premake-core/releases/download/v5.0.0-alpha9/premake-5.0.0-alpha9-windows.zip', 'premake.zip')"
+powershell -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/premake/premake-core/releases/download/v5.0.0-beta2/premake-5.0.0-beta2-windows.zip', 'premake.zip')"
 
 REM Extract premake
 powershell -Command "Expand-Archive -Path %cd%\premake.zip -DestinationPath %cd% -Force;"

--- a/setup.sh
+++ b/setup.sh
@@ -41,11 +41,11 @@ fi
 if ! [ -e premake.tar.gz ]; then
   echo "Downloading premake binaries..."
   if [ "$(uname)" == "Darwin" ]; then
-    curl -L -o premake.tar.gz https://github.com/premake/premake-core/releases/download/v5.0.0-alpha9/premake-5.0.0-alpha9-macosx.tar.gz
+    curl -L -o premake.tar.gz https://github.com/premake/premake-core/releases/download/v5.0.0-beta2/premake-5.0.0-beta2-macosx.tar.gz
   elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    curl -L -o premake.tar.gz https://github.com/premake/premake-core/releases/download/v5.0.0-alpha9/premake-5.0.0-alpha9-linux.tar.gz
+    curl -L -o premake.tar.gz https://github.com/premake/premake-core/releases/download/v5.0.0-beta2/premake-5.0.0-beta2-linux.tar.gz
   elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ] || [ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ]; then
-    curl -L -o premake.zip https://github.com/premake/premake-core/releases/download/v5.0.0-alpha9/premake-5.0.0-alpha9-windows.zip
+    curl -L -o premake.zip https://github.com/premake/premake-core/releases/download/v5.0.0-beta2/premake-5.0.0-beta2-windows.zip
   fi
 
   echo "Extracting premake binaries..."


### PR DESCRIPTION
As discussed in [Issue 8](https://github.com/thejustinwalsh/libbulletml/issues/8), the library currently fails to build because it uses an old version of premake. This change updates the setup scripts to use a more recent version. 